### PR TITLE
feature: add stub NLIValidationSkill with logging, typed tests, and m…

### DIFF
--- a/medsentinel/skills/nli_validation.py
+++ b/medsentinel/skills/nli_validation.py
@@ -1,0 +1,74 @@
+"""
+NLIValidationSkill — Stub Skill for Natural Language Inference Validation
+
+This module provides an interface and stub implementation for validating whether
+a Chain-of-Thought (CoT) explanation contradicts the grounded evidence using NLI-style logic.
+
+Features:
+- Accepts grounded evidence (premise) and generated explanation (hypothesis)
+- Returns a mocked NLI verdict: 'entailment', 'neutral', or 'contradiction'
+- Confidence score is a placeholder (float between 0 and 1)
+
+NOTE: This is a stub for future integration with models like `roberta-large-mnli` or Vertex AI NLI.
+
+Intended Use:
+- As part of hallucination-safe reasoning in agentic QA pipelines
+
+Inputs:
+- `premise` (str): factual evidence from retrieval or symbolic check
+- `hypothesis` (str): model-generated explanation or statement
+
+Outputs:
+- Dictionary with 'verdict' and 'confidence'
+
+Example Usage:
+>>> skill = NLIValidationSkill()
+>>> skill.run("The patient consumes 3500mg of sodium daily.", "The patient is within recommended sodium limits.")
+{"verdict": "contradiction", "confidence": 0.92}
+
+Author: MedSentinel Project — 2025
+"""
+
+import logging
+from typing import Dict, Any
+from medsentinel.skills.base import BaseSkill
+
+# Initialize Logging
+logger = logging.getLogger(__name__)
+
+
+class NLIValidationSkill(BaseSkill):
+    def __init__(self) -> None:
+        super().__init__(skill_name="NLIValidationSkill")
+
+    def run(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        premise = input_data.get("premise", "")
+        hypothesis = input_data.get("hypothesis", "")
+
+        logger.info(
+            f"NLIValidationSkill input — Premise: '{premise}' | Hypothesis: '{hypothesis}'"
+        )
+
+        # Stub logic — will be replaced with model later
+        if (
+            "3500mg of sodium" in premise
+            and "within recommended sodium limits" in hypothesis
+        ):
+            verdict = "contradiction"
+            confidence = 0.92
+        elif "salt" in hypothesis and "salt" not in premise:
+            verdict = "contradiction"
+            confidence = 0.92
+        elif "sodium" in hypothesis and "sodium" not in premise:
+            verdict = "contradiction"
+            confidence = 0.92
+        elif "not" in hypothesis:
+            verdict = "neutral"
+            confidence = 0.75
+        else:
+            verdict = "entailment"
+            confidence = 0.95
+
+        result = {"verdict": verdict, "confidence": confidence}
+        logger.info(f"NLIValidationSkill output — {result}")
+        return result

--- a/tests/test_nli_validation.py
+++ b/tests/test_nli_validation.py
@@ -1,0 +1,32 @@
+import pytest
+from medsentinel.skills.nli_validation import NLIValidationSkill
+
+
+@pytest.mark.parametrize(  # type: ignore[misc]
+    "premise, hypothesis, expected_verdict",
+    [
+        (
+            "The patient consumes 3500mg of sodium daily.",
+            "The patient is within recommended sodium limits.",
+            "contradiction",
+        ),
+        (
+            "The patient follows a low-sodium diet.",
+            "The patient consumes too much salt.",
+            "contradiction",
+        ),
+        (
+            "The patient eats vegetables.",
+            "The patient does not eat vegetables.",
+            "neutral",
+        ),
+        ("The patient drinks water.", "The patient stays hydrated.", "entailment"),
+    ],
+)
+def test_nli_validation_stub(
+    premise: str, hypothesis: str, expected_verdict: str
+) -> None:
+    skill = NLIValidationSkill()
+    output = skill.run({"premise": premise, "hypothesis": hypothesis})
+    assert output["verdict"] == expected_verdict
+    assert 0.0 <= output["confidence"] <= 1.0


### PR DESCRIPTION
Summary
This PR adds the NLIValidationSkill stub module to the MedSentinel agentic pipeline. This skill simulates Natural Language Inference (NLI) classification between:

- [ ] - Premise: Grounded evidence from RAG or structured checks
- [ ] - Hypothesis: Chain-of-Thought generated explanation

Key Changes

- [ ] - Implemented skills/nli_validation.py with a BaseSkill-compliant stub
- [ ] - Supports mocked verdicts: "entailment", "neutral", "contradiction"
- [ ] - Added logging for both input and output
- [ ] - Hardcoded domain-specific rule for sodium-related contradiction
- [ ] - Added type-safe unit tests in tests/test_nli_validation.py
- [ ] - Resolved all mypy, ruff, black, and pytest checks via make check